### PR TITLE
docs: updated consideration for accessing vpc clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The VPN server is deployed in a selected multizone (MZR) region and VPC.
 - **VPN Server authentication**: The VPN server certificate is needed at the time of provisioning of the VPN server. The server certificate CRN in the IBM Cloud Secrets Manager is required.
 - **VPN Client authentication**: The client authentication method is required at the time of provisioning of the VPN server. The VPN server supports "username" based authentication. There is no support for the "certificate" based authentication at this point of time.
 - **Split tunnel mode**: This module provisions a client-to-site VPN with the split tunnel mode. When the VPN connection is set up, an encrypted tunnel is created over the internet to the VPN server. The split tunnel mode supports sending private traffic that is destined to the VPC inside the VPN tunnel and sending public traffic (internet traffic) outside the VPN tunnel.
-- **Accessing VPC clusters**:
+- **Accessing the VPC clusters**:
   - Through the private service endpoint: Set up `vpn_server_routes` as mentioned [here](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_private_se).
   - Through the Virtual Private Endpoint (VPE) gateway: Set up `vpn_server_routes` as mentioned [here](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#vpc_vpe).
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ The VPN server is deployed in a selected multizone (MZR) region and VPC.
 - **VPN Server authentication**: The VPN server certificate is needed at the time of provisioning of the VPN server. The server certificate CRN in the IBM Cloud Secrets Manager is required.
 - **VPN Client authentication**: The client authentication method is required at the time of provisioning of the VPN server. The VPN server supports "username" based authentication. There is no support for the "certificate" based authentication at this point of time.
 - **Split tunnel mode**: This module provisions a client-to-site VPN with the split tunnel mode. When the VPN connection is set up, an encrypted tunnel is created over the internet to the VPN server. The split tunnel mode supports sending private traffic that is destined to the VPC inside the VPN tunnel and sending public traffic (internet traffic) outside the VPN tunnel.
-- **Accessing the VPC clusters**:
-  - Through the private service endpoint: Set up `vpn_server_routes` as mentioned [here](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_private_se).
-  - Through the Virtual Private Endpoint (VPE) gateway: Set up `vpn_server_routes` as mentioned [here](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#vpc_vpe).
+- **Accessing the VPC clusters**: Set CIDR blocks to allow VPN access to your VPC cluster through either the private service endpoint or the Virtual Private Endpoint Gateway. Specify the block in the `vpn_server_routes` input. For more information about the routes, see [Accessing clusters through the private cloud service endpoint](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_private_se) and [through the Virtual Private Endpoint Gateway](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#vpc_vpe).
 
 ### Setting up a client VPN environment and connecting to a VPN server
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The VPN server is deployed in a selected multizone (MZR) region and VPC.
 - **VPN Server authentication**: The VPN server certificate is needed at the time of provisioning of the VPN server. The server certificate CRN in the IBM Cloud Secrets Manager is required.
 - **VPN Client authentication**: The client authentication method is required at the time of provisioning of the VPN server. The VPN server supports "username" based authentication. There is no support for the "certificate" based authentication at this point of time.
 - **Split tunnel mode**: This module provisions a client-to-site VPN with the split tunnel mode. When the VPN connection is set up, an encrypted tunnel is created over the internet to the VPN server. The split tunnel mode supports sending private traffic that is destined to the VPC inside the VPN tunnel and sending public traffic (internet traffic) outside the VPN tunnel.
+- **Accessing VPC clusters**:
+  - Through the private service endpoint: Set up `vpn_server_routes` as mentioned [here](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_private_se).
+  - Through the Virtual Private Endpoint (VPE) gateway: Set up `vpn_server_routes` as mentioned [here](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#vpc_vpe).
 
 ### Setting up a client VPN environment and connecting to a VPN server
 


### PR DESCRIPTION
### Description

Added `vpn_server_routes` consideration for accessing the VPC cluster via private service endpoint and the VPE gateway.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
